### PR TITLE
Change observer to allow sending references without moving data.

### DIFF
--- a/include/etl/observer.h
+++ b/include/etl/observer.h
@@ -232,9 +232,31 @@ namespace etl
       return observer_list.size();
     }
 
+#if ETL_CPP11_SUPPORTED && !defined(ETL_OBSERVER_FORCE_CPP03)
     //*****************************************************************
     /// Notify all of the observers, sending them the notification.
-    ///\tparam TNotification The notification type.
+    ///\tparam TNotification the notification type.
+    ///\param n The notification.
+    //*****************************************************************
+    template <typename TNotification>
+    void notify_observers(TNotification&& n)
+    {
+      typename Observer_List::iterator i_observer_item = observer_list.begin();
+
+      while (i_observer_item != observer_list.end())
+      {
+        if (i_observer_item->enabled)
+        {
+          i_observer_item->p_observer->notification(n);
+        }
+
+        ++i_observer_item;
+      }
+    }
+#else
+    //*****************************************************************
+    /// Notify all of the observers, sending them the notification.
+    ///\tparam TNotification the notification type.
     ///\param n The notification.
     //*****************************************************************
     template <typename TNotification>
@@ -252,6 +274,7 @@ namespace etl
         ++i_observer_item;
       }
     }
+#endif
 
   protected:
 


### PR DESCRIPTION
This should allow references to work without moving data. The previous version used `std::forward`, which is undesirable. If the observer is looking for a copy, it will receive a copy.